### PR TITLE
feat: Pull production webui using kubo cli

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
 use asdf
 
-dotenv
+dotenv ".env"
+dotenv ".env-private"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/bin
+frontend
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,macos,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=go,macos,windows,linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/bin
 frontend
+.env-private
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,macos,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=go,macos,windows,linux

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "webui"]
-	path = frontend
-	url = git@github.com:ipfs/ipfs-webui.git
-    branch = main
-    ignore = dirty

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See https://wails.io/docs/gettingstarted/installation
 ### Run a local version
 
 ```bash
-git submodule update --init --recursive --remote
+./get-webui.sh
 wails dev
 ```
 

--- a/get-webui.sh
+++ b/get-webui.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# see https://github.com/ipfs/kubo/blob/839b0848aec623ca68975efe7b628b06054074bf/core/corehttp/webui.go#L4
+# or
+# https://github.com/ipfs/ipfs-webui/releases
+# WEBUI_CID=bafybeihfkeactw26tghz7m3puzh4zqlukvft2f7atfdc7t2qmqn2vszhc4 #v2.17.3
+WEBUI_CID=bafybeibozpulxtpv5nhfa2ue3dcjx23ndh3gwr5vwllk7ptoyfwnfjjr4q #v2.15.1
+
+main() {
+  ipfs get "/ipfs/$WEBUI_CID" -o frontend
+}
+
+main

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
-//go:embed frontend/public
+//go:embed frontend
 var assets embed.FS
 
 func main() {

--- a/wails.json
+++ b/wails.json
@@ -1,9 +1,9 @@
 {
   "name": "ipfs-desktop",
-  "frontend:build": "npm run build",
-  "frontend:install": "npm ci",
-  "frontend:dev": "npm run build",
-  "frontend:dev:watcher": "npx --yes serve -u build",
+  "frontend:build": "",
+  "frontend:install": "",
+  "frontend:dev": "",
+  "frontend:dev:watcher": "npx --yes serve -u .",
   "frontend:dev:serverUrl": "http://localhost:3000",
   "wailsjsdir": "./frontend",
   "version": "2",


### PR DESCRIPTION
this PR updates this repo to consume the webui via `ipfs get "/ipfs/$CID"` instead of via a submodule that needs to be built.